### PR TITLE
Feature/use symfony cache instead of doctrine cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           php-version: "7.4"
 
       - name: "Cache composer packages"
-        uses: "actions/cache@v2"
+        uses: "actions/cache@v3"
         with:
           path: "~/.composer/cache"
           key: "php-composer-locked-${{ hashFiles('composer.lock') }}"
@@ -53,7 +53,7 @@ jobs:
                 php-version: "8"
 
           - name: "Cache composer packages"
-            uses: "actions/cache@v2"
+            uses: "actions/cache@v3"
             with:
                 path: "~/.composer/cache"
                 key: "php-composer-locked-${{ hashFiles('composer.lock') }}"
@@ -89,7 +89,7 @@ jobs:
           php-version: "8.1"
 
       - name: "Cache composer packages"
-        uses: "actions/cache@v2"
+        uses: "actions/cache@v3"
         with:
           path: "~/.composer/cache"
           key: "php-composer-locked-${{ hashFiles('composer.lock') }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           fetch-depth: 2
 
@@ -43,7 +43,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
           - name: "Checkout"
-            uses: "actions/checkout@v2"
+            uses: "actions/checkout@v3"
             with:
                 fetch-depth: 2
 
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           fetch-depth: 2
 

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
     "illuminate/support": "^8.0|^9.0|^10.0",
     "illuminate/contracts": "^8.0|^9.0|^10.0",
     "jms/serializer": "^3.18",
-    "php": "^7.4|^8.0|^8.1",
-    "symfony/cache": "^6.2"
+    "php": "^7.4|^8.0|^8.1"
   },
   "autoload": {
     "psr-4": {
@@ -43,7 +42,8 @@
     "nunomaduro/larastan": "^1.0|^2.0",
     "orchestra/testbench": "^6.0|^7.0",
     "phpstan/phpstan-phpunit": "^1.1",
-    "php-parallel-lint/php-parallel-lint": "^1.3"
+    "php-parallel-lint/php-parallel-lint": "^1.3",
+    "symfony/cache": "^6.2"
   },
   "scripts": {
     "lint": "parallel-lint --exclude .git --exclude vendor .",

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "orchestra/testbench": "^6.0|^7.0",
     "phpstan/phpstan-phpunit": "^1.1",
     "php-parallel-lint/php-parallel-lint": "^1.3",
-    "symfony/cache": "^6.2"
+    "symfony/cache": "^5.4|^6.2"
   },
   "scripts": {
     "lint": "parallel-lint --exclude .git --exclude vendor .",

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     "illuminate/support": "^8.0|^9.0|^10.0",
     "illuminate/contracts": "^8.0|^9.0|^10.0",
     "jms/serializer": "^3.18",
-    "doctrine/cache": "^1.10",
-    "php": "^7.4|^8.0|^8.1"
+    "php": "^7.4|^8.0|^8.1",
+    "symfony/cache": "^6.2"
   },
   "autoload": {
     "psr-4": {
@@ -51,7 +51,7 @@
     "cs-fix": "php-cs-fixer --using-cache=no fix",
     "test": "phpunit",
     "test-coverage": "phpunit --coverage-clover build/logs/clover.xml",
-    "analyze": "phpstan analyze --no-progress --memory-limit=-1",
+    "analyze": "phpstan analyze --no-progress --memory-limit=-1 --xdebug",
     "update-baseline": "phpstan analyze --generate-baseline --memory-limit=-1",
     "check": [
       "@cs-check",

--- a/tests/Http/Responses/ResponseFactoryTest.php
+++ b/tests/Http/Responses/ResponseFactoryTest.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Dropelikeit\LaravelJmsSerializer\Tests\Http\Responses;
 
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Dropelikeit\LaravelJmsSerializer\Config\Config;
 use Dropelikeit\LaravelJmsSerializer\Contracts;
 use Dropelikeit\LaravelJmsSerializer\Exception\SerializeType;
@@ -28,8 +27,6 @@ final class ResponseFactoryTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-
-        AnnotationRegistry::registerLoader('class_exists');
 
         $this->config = $this
             ->getMockBuilder(Contracts\Config::class)


### PR DESCRIPTION
`doctrine/cache` is deprecated and should not be used anymore. Therefore, we now use the library `symfony/cache` to cache our generated annotations. `symfony/cache` is only used for the development of this library and no longer for the integration into other projects. Each project should have its own psr-6 / psr-16 cache to cache automatically generated annotations. By the way, Laravel has a cache by default, so there is no need to bring a cache for annotations by the library.