### PR TITLE
Upgrade illuminate dependencies, add UPGRADE-6.0.md file

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -1,0 +1,18 @@
+# UPGRADE FROM 5.x.x TO 6.0.0
+
+### Breaking Changes
+
+Version 6 of this package no longer supports Laravel 9.
+Since Laravel has not provided version 9 with updates since 06/02/2024.
+Since Laravel 10+ requires PHP 8.1, this PHP version is also required in this library.
+---
+
+### Features
+
+- This package can now be used with Laravel v10 and v11+.
+- Removed Coveralls support into github actions.
+
+### Patches
+
+- The mutation value has been improved to 100%.
+- The coverage of the units has been improved to 97% of the lines.

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
   ],
   "require": {
     "php": "^8.1|^8.2|^8.3",
-    "illuminate/http": "^9.0|^10.0|^11.0",
-    "illuminate/support": "^9.0|^10.0|^11.0",
-    "illuminate/contracts": "^9.0|^10.0|^11.0",
+    "illuminate/http": "^10.0|^11.0",
+    "illuminate/support": "^10.0|^11.0",
+    "illuminate/contracts": "^10.0|^11.0",
     "jms/serializer": "^3.30"
   },
   "autoload": {


### PR DESCRIPTION
Illuminated requirements have been upgraded to only support versions 10.0 and 11.0, which reflect in the changes made in composer.json. Additionally, an UPGRADE-6.0.md file was added to provide a guide on moving from version 5.x.x to 6.0.0. This guide specifically highlights the unsupported Laravel 9 version.