### PR TITLE
Update target branch in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
     pull_request:
     push:
       branches:
-        - main
+        - master
 
 jobs:
   php81:


### PR DESCRIPTION
Change has been made in GitHub Actions CI workflow file to have the push and pull requests on 'master' branch instead of 'main'. This will make sure that the automated tests are run only on changes to the 'master' branch.